### PR TITLE
eslint-config-seekingalpha-base ver 1.1.0 update

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-base/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-base/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change Log
 
+## 1.1.0 - 2018-08-16
+ - [new] introduce `seekingalpha-base/browser` and `seekingalpha-base/node` shareable configurations
+ - [deps] update `eslint-plugin-import` to version 2.14.0 
+ - [patch] disable `init-declarations` rule
+ - [patch] disable `no-invalid-this` rule
+
 ## 1.0.4 - 2018-08-15
 
- - [minor] loosen `max-len` rule extending max line lenght to 150 chars
+ - [minor] loosen `max-len` rule extending max line length to 150 chars
  - [fix] `dot-notation` rule allowing keywords
  - [patch] disable `func-names` rule
  

--- a/eslint-configs/eslint-config-seekingalpha-base/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-base/README.md
@@ -6,11 +6,11 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESlint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/) with **NPM**:
 
-    npm install eslint@"^5.3.0" eslint-plugin-array-func@"^3.0.0" eslint-plugin-import@"^2.13.0" eslint-plugin-jsdoc@"^3.7.1" eslint-plugin-no-use-extend-native@"^0.3.12" eslint-plugin-promise@"^3.8.0" eslint-plugin-unicorn@"^5.0.0" --save-dev
+    npm install eslint@"^5.3.0" eslint-plugin-array-func@"^3.0.0" eslint-plugin-import@"^2.14.0" eslint-plugin-jsdoc@"^3.7.1" eslint-plugin-no-use-extend-native@"^0.3.12" eslint-plugin-promise@"^3.8.0" eslint-plugin-unicorn@"^5.0.0" --save-dev
 
 or **Yarn**:
 
-    yarn add --dev eslint@^5.3.0 eslint-plugin-array-func@^3.0.0 eslint-plugin-import@^2.13.0 eslint-plugin-jsdoc@^3.7.1 eslint-plugin-no-use-extend-native@^0.3.12 eslint-plugin-promise@^3.8.0 eslint-plugin-unicorn@^5.0.0
+    yarn add --dev eslint@^5.3.0 eslint-plugin-array-func@^3.0.0 eslint-plugin-import@^2.14.0 eslint-plugin-jsdoc@^3.7.1 eslint-plugin-no-use-extend-native@^0.3.12 eslint-plugin-promise@^3.8.0 eslint-plugin-unicorn@^5.0.0
 
     
 Install SeekingAlpha shareable ESLint:
@@ -32,14 +32,36 @@ This shareable config includes all ESLint rules including ECMAScript 6 features 
 * [eslint-plugin-promise](https://github.com/xjamundx/eslint-plugin-promise)
 * [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn)
 
-Simply [extend](https://eslint.org/docs/user-guide/configuring#extending-configuration-files) the relevant .eslintrc.js configuration in your project with `seekingalpha-base` rules:
+We expose three configurations:
+
+* `seekingalpha-base` - exports all avaliable ESLint [rules](https://eslint.org/docs/rules/) and all rules of plugins above.
+* `seekingalpha-base/browser` - exports only browser related rules for ESLint and mentioned plugins. It also sets `browser` as [default environment](https://eslint.org/docs/user-guide/configuring#specifying-environments).
+* `seekingalpha-base/node` - exports only Node.js related rules for ESLint and mentioned plugins. It also sets `node` as [default environment](https://eslint.org/docs/user-guide/configuring#specifying-environments). 
+
+
+Simply [extend](https://eslint.org/docs/user-guide/configuring#extending-configuration-files) the .eslintrc.js in your project with relevant configuration:
 
 ```javascript
+// for seekingalpha-base
 {
   extends: [
     'seekingalpha-base'
   ]
 }  
+
+// for seekingalpha-base/browser
+{
+  extends: [
+    'seekingalpha-base/browser'
+  ]
+}
+
+// for seekingalpha-base/node
+{
+  extends: [
+    'seekingalpha-base/node'
+  ]
+}
 ```
 
 ## License

--- a/eslint-configs/eslint-config-seekingalpha-base/browser.js
+++ b/eslint-configs/eslint-config-seekingalpha-base/browser.js
@@ -5,7 +5,7 @@ module.exports = {
     './rules/parser-options.js',
 
     // ESLint rules (https://eslint.org/docs/rules/)
-    './rules/eslint/index.js',
+    './rules/eslint/browser.js',
 
     // eslint-plugin-import rules (https://github.com/benmosher/eslint-plugin-import)
     './rules/eslint-plugin-import/index.js',
@@ -28,9 +28,7 @@ module.exports = {
   ],
 
   env: {
-    browser: true,
-    node: true,
-    'shared-node-browser': true
+    browser: true
   }
 
 };

--- a/eslint-configs/eslint-config-seekingalpha-base/node.js
+++ b/eslint-configs/eslint-config-seekingalpha-base/node.js
@@ -1,0 +1,18 @@
+module.exports = {
+
+  extends: [
+
+    './rules/parser-options.js',
+
+    // ESLint rules (https://eslint.org/docs/rules/)
+    './rules/eslint/nodejs-and-commonjs.js',
+
+    './rules/eslint-plugin-unicorn/node.js'
+
+  ],
+
+  env: {
+    node: true
+  }
+
+};

--- a/eslint-configs/eslint-config-seekingalpha-base/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-base",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "SeekingAlpha's sharable base ESLint config",
   "main": "index.js",
   "scripts": {
@@ -28,6 +28,12 @@
     "guide"
   ],
   "author": "Aleksey Kovalevsky",
+  "contributors": [
+    {
+      "name": "Artem Prokhatskyi",
+      "url": "https://github.com/prokhatskiy"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/seekingalpha/javascript/issues"
@@ -39,7 +45,7 @@
   "devDependencies": {
     "eslint": "^5.3.0",
     "eslint-plugin-array-func": "^3.0.0",
-    "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsdoc": "^3.7.1",
     "eslint-plugin-no-use-extend-native": "^0.3.12",
     "eslint-plugin-promise": "^3.8.0",
@@ -48,7 +54,7 @@
   "peerDependencies": {
     "eslint": "^5.3.0",
     "eslint-plugin-array-func": "^3.0.0",
-    "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsdoc": "^3.7.1",
     "eslint-plugin-no-use-extend-native": "^0.3.12",
     "eslint-plugin-promise": "^3.8.0",

--- a/eslint-configs/eslint-config-seekingalpha-base/rules/eslint-plugin-unicorn/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-base/rules/eslint-plugin-unicorn/index.js
@@ -6,6 +6,8 @@ module.exports = {
 
   rules: {
 
+    extends: ['./node.js'],
+
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/catch-error-name.md
     'unicorn/catch-error-name': [
       'error',

--- a/eslint-configs/eslint-config-seekingalpha-base/rules/eslint-plugin-unicorn/node.js
+++ b/eslint-configs/eslint-config-seekingalpha-base/rules/eslint-plugin-unicorn/node.js
@@ -1,0 +1,14 @@
+// https://github.com/sindresorhus/eslint-plugin-unicorn
+
+module.exports = {
+
+  plugins: ['unicorn'],
+
+  rules: {
+
+    // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-new-buffer.md
+    'unicorn/no-new-buffer': 'error'
+
+  }
+
+};

--- a/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/best-practices.js
+++ b/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/best-practices.js
@@ -145,7 +145,7 @@ module.exports = {
     'no-implied-eval': 'error',
 
     // https://eslint.org/docs/rules/no-invalid-this
-    'no-invalid-this': 'error',
+    'no-invalid-this': 'off',
 
     // https://eslint.org/docs/rules/no-iterator
     'no-iterator': 'error',

--- a/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/browser.js
+++ b/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/browser.js
@@ -1,0 +1,13 @@
+module.exports = {
+
+  extends: [
+    './possible-errors.js',
+    './best-practices.js',
+    './strict-mode.js',
+    './variables.js',
+    './stylistic-issues.js',
+    './ecma-script-6.js',
+    './deprecated.js'
+  ]
+
+};

--- a/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/index.js
@@ -1,14 +1,8 @@
 module.exports = {
 
   extends: [
-    './possible-errors.js',
-    './best-practices.js',
-    './strict-mode.js',
-    './variables.js',
-    './nodejs-and-commonjs.js',
-    './stylistic-issues.js',
-    './ecma-script-6.js',
-    './deprecated.js'
+    './browser.js',
+    './nodejs-and-commonjs.js'
   ]
 
 };

--- a/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/variables.js
+++ b/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/variables.js
@@ -6,7 +6,7 @@ module.exports = {
 
     // https://eslint.org/docs/rules/init-declarations
     'init-declarations': [
-      'error',
+      'off',
       'always'
     ],
 

--- a/eslint-configs/eslint-config-seekingalpha-base/rules/parser-options.js
+++ b/eslint-configs/eslint-config-seekingalpha-base/rules/parser-options.js
@@ -1,0 +1,8 @@
+module.exports = {
+
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module'
+  }
+
+};


### PR DESCRIPTION
 - [new] introduce `seekingalpha-base/browser` and `seekingalpha-base/node` shareable configurations

 - [deps] update `eslint-plugin-import` to version 2.14.0

 - [patch] disable `init-declarations` rule

 - [patch] disable `no-invalid-this` rule

 - [docs] update installation guide