### PR TITLE
eslint-config-seekingalpha-react version 1.4.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
@@ -17,6 +17,7 @@
  - [new] `jest/valid-expect` rule error
  - [new] `jest/valid-expect-in-promise` rule error
  - [new] `jsx-a11y/label-has-associated-control` rule error
+ - [new] `react/no-danger` rule error
 
 ## 1.3.0 - 2018-12-11
  - [deps] update `eslint-config-seekingalpha-base` to version 1.5.1

--- a/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Change Log
 
+## 1.4.0 - 2018-12-18
+ - [deps] update `eslint-config-seekingalpha-base` to version 1.6.0
+ - [new] `flowtype/require-compound-type-alias` rule error with `never` option
+ - [new] `jest/consistent-test-it` rule error
+ - [new] `jest/expect-expect` rule error
+ - [new] `jest/no-jasmine-globals` rule error
+ - [new] `jest/no-jest-import` rule error
+ - [new] `jest/no-large-snapshots` rule error with `maxSize: 50` option
+ - [new] `jest/no-test-prefixes` rule error
+ - [new] `jest/no-test-return-statement` rule error
+ - [new] `jest/prefer-strict-equal` rule error
+ - [new] `jest/prefer-to-be-null` rule error
+ - [new] `jest/prefer-to-be-undefined` rule error
+ - [new] `jest/valid-describe` rule error
+ - [new] `jest/valid-expect` rule error
+ - [new] `jest/valid-expect-in-promise` rule error
+ - [new] `jsx-a11y/label-has-associated-control` rule error
+
 ## 1.3.0 - 2018-12-11
  - [deps] update `eslint-config-seekingalpha-base` to version 1.5.1
  - [deps] update `eslint` to version 5.10.0

--- a/eslint-configs/eslint-config-seekingalpha-react/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-react/package.json
@@ -1,9 +1,10 @@
 {
   "name": "eslint-config-seekingalpha-react",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "SeekingAlpha's sharable React.js ESLint config",
   "main": "index.js",
   "scripts": {
+    "eslint-find-rules": "eslint-find-rules -u ./index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -48,7 +49,7 @@
     "node": ">= 7"
   },
   "dependencies": {
-    "eslint-config-seekingalpha-base": "1.5.1"
+    "eslint-config-seekingalpha-base": "1.6.0"
   },
   "peerDependencies": {
     "babel-eslint": "10.0.1",

--- a/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-flowtype/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-flowtype/index.js
@@ -156,6 +156,18 @@ module.exports = {
     // https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-use-flow-type
     'flowtype/use-flow-type': 'warn',
 
+    // https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-require-compound-type-alias
+    'flowtype/require-compound-type-alias': [
+      'error',
+      'never',
+    ],
+
+    // https://github.com/gajus/eslint-plugin-flowtype#require-exact-type
+    'flowtype/require-exact-type': 'off',
+
+    // https://github.com/gajus/eslint-plugin-flowtype#sort-keys
+    'flowtype/sort-keys': 'off',
+
   },
 
   settings: {

--- a/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-jest/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-jest/index.js
@@ -34,6 +34,63 @@ module.exports = {
 
     // https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/no-truthy-falsy.md
     'jest/no-truthy-falsy': 'error',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/consistent-test-it.md
+    'jest/consistent-test-it': 'error',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/expect-expect.md
+    'jest/expect-expect': 'error',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/lowercase-name.md
+    'jest/lowercase-name': 'off',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-jasmine-globals.md
+    'jest/no-jasmine-globals': 'error',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-jest-import.md
+    'jest/no-jest-import': 'error',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-large-snapshots.md
+    'jest/no-large-snapshots': [
+      'error',
+      {
+        maxSize: 50,
+      },
+    ],
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-test-prefixes.md
+    'jest/no-test-prefixes': 'error',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-test-return-statement.md
+    'jest/no-test-return-statement': 'error',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-expect-assertions.md
+    'jest/prefer-expect-assertions': 'off',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-inline-snapshots.md
+    'jest/prefer-inline-snapshots': 'off',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-strict-equal.md
+    'jest/prefer-strict-equal': 'error',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-to-be-null.md
+    'jest/prefer-to-be-null': 'error',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-hooks.md
+    'jest/no-hooks': 'off',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-to-be-undefined.md
+    'jest/prefer-to-be-undefined': 'error',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-describe.md
+    'jest/valid-describe': 'error',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-expect.md
+    'jest/valid-expect': 'error',
+
+    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-expect-in-promise.md
+    'jest/valid-expect-in-promise': 'error',
+
   },
 
 };

--- a/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-jsx-a11y/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-jsx-a11y/index.js
@@ -281,6 +281,9 @@ module.exports = {
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/tabindex-no-positive.md
     'jsx-a11y/tabindex-no-positive': 'error',
 
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md
+    'jsx-a11y/label-has-associated-control': 'error',
+
   },
 
 };

--- a/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-react/jsx.js
+++ b/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-react/jsx.js
@@ -218,7 +218,7 @@ module.exports = {
     ],
 
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger.md
-    'react/no-danger': 'off',
+    'react/no-danger': 'error',
 
   },
 

--- a/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-react/jsx.js
+++ b/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-react/jsx.js
@@ -217,6 +217,9 @@ module.exports = {
       },
     ],
 
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger.md
+    'react/no-danger': 'off',
+
   },
 
 };


### PR DESCRIPTION
- [deps] update `eslint-config-seekingalpha-base` to version 1.6.0
- [new] `flowtype/require-compound-type-alias` rule error with `never` option
- [new] `jest/consistent-test-it` rule error
- [new] `jest/expect-expect` rule error
- [new] `jest/no-jasmine-globals` rule error
- [new] `jest/no-jest-import` rule error
- [new] `jest/no-large-snapshots` rule error with `maxSize: 50` option
- [new] `jest/no-test-prefixes` rule error
- [new] `jest/no-test-return-statement` rule error
- [new] `jest/prefer-strict-equal` rule error
- [new] `jest/prefer-to-be-null` rule error
- [new] `jest/prefer-to-be-undefined` rule error
- [new] `jest/valid-describe` rule error
- [new] `jest/valid-expect` rule error
- [new] `jest/valid-expect-in-promise` rule error
- [new] `jsx-a11y/label-has-associated-control` rule error