### PR TITLE
eslint-config-seekingalpha-react ver. 2.6.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.6.0 - 2019-06-16
+ - [deps] upgrade `eslint-plugin-flowtype` to version 3.10.3
+ - [new] `flowtype/delimiter-dangle` enable with 'always' option
+
 ## 2.5.1 - 2019-06-12
  - [loosen rules] `flowtype/require-return-type` disabled
 

--- a/eslint-configs/eslint-config-seekingalpha-react/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-react/README.md
@@ -6,11 +6,11 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESlint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/) with **NPM**:
 
-    npm install babel-eslint@10.0.1 eslint@5.16.0 eslint-plugin-flowtype@3.10.1 eslint-plugin-jest@22.6.4 eslint-plugin-jsx-a11y@6.2.1 eslint-plugin-react@7.13.0 eslint-plugin-react-hooks@1.6.0 --save-dev
+    npm install babel-eslint@10.0.1 eslint@5.16.0 eslint-plugin-flowtype@3.10.3 eslint-plugin-jest@22.6.4 eslint-plugin-jsx-a11y@6.2.1 eslint-plugin-react@7.13.0 eslint-plugin-react-hooks@1.6.0 --save-dev
 
 or **Yarn**:
 
-    yarn add --dev babel-eslint@10.0.1 eslint@5.16.0 eslint-plugin-flowtype@3.10.1 eslint-plugin-jest@22.6.4 eslint-plugin-jsx-a11y@6.2.1 eslint-plugin-react@7.13.0 eslint-plugin-react-hooks@1.6.0
+    yarn add --dev babel-eslint@10.0.1 eslint@5.16.0 eslint-plugin-flowtype@3.10.3 eslint-plugin-jest@22.6.4 eslint-plugin-jsx-a11y@6.2.1 eslint-plugin-react@7.13.0 eslint-plugin-react-hooks@1.6.0
 
 
 Install SeekingAlpha shareable ESLint:

--- a/eslint-configs/eslint-config-seekingalpha-react/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-react",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "SeekingAlpha's sharable React.js ESLint config",
   "main": "index.js",
   "scripts": {
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "babel-eslint": "10.0.1",
     "eslint": "5.16.0",
-    "eslint-plugin-flowtype": "3.10.1",
+    "eslint-plugin-flowtype": "3.10.3",
     "eslint-plugin-jest": "22.6.4",
     "eslint-plugin-jsx-a11y": "6.2.1",
     "eslint-plugin-react": "7.13.0",
@@ -61,7 +61,7 @@
     "babel-eslint": "10.0.1",
     "eslint": "5.16.0",
     "eslint-find-rules": "3.3.1",
-    "eslint-plugin-flowtype": "3.10.1",
+    "eslint-plugin-flowtype": "3.10.3",
     "eslint-plugin-jest": "22.6.4",
     "eslint-plugin-jsx-a11y": "6.2.1",
     "eslint-plugin-react": "7.13.0",

--- a/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-flowtype/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-flowtype/index.js
@@ -30,7 +30,7 @@ module.exports = {
     // https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-delimiter-dangle
     'flowtype/delimiter-dangle': [
       'error',
-      'never',
+      'always',
     ],
 
     // https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-generic-spacing


### PR DESCRIPTION
- [deps] upgrade `eslint-plugin-flowtype` to version 3.10.3
- [new] `flowtype/delimiter-dangle` enable with 'always' option