### PR TITLE
eslint-config-seekingalpha-qa ver. 1.1.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-qa/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-qa/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
 
+## 1.1.0 - 2018-07-17
+ - [breaking] `mocha/valid-suite-description` updated validation regex to be `^[A-Z]\\d+: should`
+
 ## 1.0.0 - 2018-07-11
  - Initial commit

--- a/eslint-configs/eslint-config-seekingalpha-qa/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-qa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-qa",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "SeekingAlpha's sharable QA ESLint config",
   "main": "index.js",
   "scripts": {

--- a/eslint-configs/eslint-config-seekingalpha-qa/rules/eslint-plugin-mocha/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-qa/rules/eslint-plugin-mocha/index.js
@@ -63,7 +63,7 @@ module.exports = {
     // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/valid-suite-description.md
     'mocha/valid-suite-description': [
       'error',
-      '^[A-Z]',
+      '^[A-Z]\\d+: should',
     ],
 
     // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/valid-test-description.md


### PR DESCRIPTION
- [breaking] `mocha/valid-suite-description` updated validation regex to be `^[A-Z]\\d+: should`