### PR TITLE
eslint-config-seekingalpha-qa ver. 1.2.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-qa/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-qa/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.2.0 - 2018-07-17
+ - [breaking] revert `mocha/valid-suite-description` validation regex to `^[A-Z]`
+ - [breaking] `mocha/valid-test-description` updated validation regex to be `^[A-Z]\\d+: should`
+
 ## 1.1.0 - 2018-07-17
  - [breaking] `mocha/valid-suite-description` updated validation regex to be `^[A-Z]\\d+: should`
 

--- a/eslint-configs/eslint-config-seekingalpha-qa/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-qa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-qa",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "SeekingAlpha's sharable QA ESLint config",
   "main": "index.js",
   "scripts": {

--- a/eslint-configs/eslint-config-seekingalpha-qa/rules/eslint-plugin-mocha/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-qa/rules/eslint-plugin-mocha/index.js
@@ -63,11 +63,14 @@ module.exports = {
     // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/valid-suite-description.md
     'mocha/valid-suite-description': [
       'error',
-      '^[A-Z]\\d+: should',
+      '^[A-Z]',
     ],
 
     // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/valid-test-description.md
-    'mocha/valid-test-description': 'error',
+    'mocha/valid-test-description': [
+      'error',
+      '^[A-Z]\\d+: should',
+    ],
 
     // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-async-describe.md
     'mocha/no-async-describe': 'error',


### PR DESCRIPTION
- [breaking] revert `mocha/valid-suite-description` validation regex to `^[A-Z]`
- [breaking] `mocha/valid-test-description` updated validation regex to be `^[A-Z]\\d+: should`