### PR TITLE
eslint-config-seekingalpha-base ver. 4.26.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-base/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-base/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 4.26.0 - 2021-01-11
+  - [deps] update `eslint-plugin-unicorn` to version `25.0.1`
+  - [breaking] enable `require-unicode-regexp` rule
+  - [breaking] enable `unicorn/consistent-destructuring` rule
+  - [breaking] enable `unicorn/no-new-array` rule
+  - [breaking] enable `unicorn/prefer-array-index-of` rule
+  - [breaking] enable `unicorn/prefer-regexp-test` rule
+
 ## 4.25.0 - 2021-01-03
   - [deps] update `eslint` to version `7.17.0`
 

--- a/eslint-configs/eslint-config-seekingalpha-base/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-base/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESLint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/):
 
-    npm install eslint@7.17.0 eslint-plugin-array-func@3.1.7 eslint-plugin-import@2.22.1 eslint-plugin-no-use-extend-native@0.5.0 eslint-plugin-promise@4.2.1 eslint-plugin-unicorn@25.0.1 --save-dev
+    npm install eslint@7.17.0 eslint-plugin-array-func@3.1.7 eslint-plugin-import@2.22.1 eslint-plugin-no-use-extend-native@0.5.0 eslint-plugin-promise@4.2.1 eslint-plugin-unicorn@26.0.0 --save-dev
 
 Install SeekingAlpha shareable ESLint:
 

--- a/eslint-configs/eslint-config-seekingalpha-base/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-base",
-  "version": "4.25.0",
+  "version": "4.26.0",
   "description": "SeekingAlpha's sharable base ESLint config",
   "main": "index.js",
   "scripts": {
@@ -53,7 +53,7 @@
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-no-use-extend-native": "0.5.0",
     "eslint-plugin-promise": "4.2.1",
-    "eslint-plugin-unicorn": "25.0.1"
+    "eslint-plugin-unicorn": "26.0.0"
   },
   "devDependencies": {
     "eslint": "7.17.0",
@@ -62,6 +62,6 @@
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-no-use-extend-native": "0.5.0",
     "eslint-plugin-promise": "4.2.1",
-    "eslint-plugin-unicorn": "25.0.1"
+    "eslint-plugin-unicorn": "26.0.0"
   }
 }

--- a/eslint-configs/eslint-config-seekingalpha-base/rules/eslint-plugin-unicorn/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-base/rules/eslint-plugin-unicorn/index.js
@@ -17,6 +17,9 @@ module.exports = {
       },
     ],
 
+    // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/consistent-destructuring.md
+    'unicorn/consistent-destructuring': 'error',
+
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/consistent-function-scoping.md
     'unicorn/consistent-function-scoping': 'error',
 
@@ -89,6 +92,9 @@ module.exports = {
      */
     'unicorn/no-nested-ternary': 'off',
 
+    // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-new-array.md
+    'unicorn/no-new-array': 'error',
+
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-new-buffer.md
     'unicorn/no-new-buffer': 'error',
 
@@ -134,6 +140,9 @@ module.exports = {
 
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-array-some.md
     'unicorn/prefer-array-some': 'error',
+
+    // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-array-index-of.md
+    'unicorn/prefer-array-index-of': 'error',
 
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-date-now.md
     'unicorn/prefer-date-now': 'error',
@@ -188,6 +197,9 @@ module.exports = {
 
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-reflect-apply.md
     'unicorn/prefer-reflect-apply': 'off',
+
+    // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-regexp-test.md
+    'unicorn/prefer-regexp-test': 'error',
 
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-set-has.md
     'unicorn/prefer-set-has': 'error',

--- a/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/best-practices.js
+++ b/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/best-practices.js
@@ -22,7 +22,7 @@ module.exports = {
     // https://eslint.org/docs/rules/block-scoped-var
     'block-scoped-var': 'error',
 
-    // https://eslint.org/docs/rules/class-methods-use-this review
+    // https://eslint.org/docs/rules/class-methods-use-this
     'class-methods-use-this': 'error',
 
     // https://eslint.org/docs/rules/complexity

--- a/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/best-practices.js
+++ b/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/best-practices.js
@@ -10,7 +10,9 @@ module.exports = {
     'accessor-pairs': [
       'error',
       {
-        getWithoutSet: true,
+        setWithoutGet: true,
+        getWithoutSet: false,
+        enforceForClassMembers: true,
       },
     ],
 
@@ -20,7 +22,7 @@ module.exports = {
     // https://eslint.org/docs/rules/block-scoped-var
     'block-scoped-var': 'error',
 
-    // https://eslint.org/docs/rules/class-methods-use-this
+    // https://eslint.org/docs/rules/class-methods-use-this review
     'class-methods-use-this': 'error',
 
     // https://eslint.org/docs/rules/complexity
@@ -351,11 +353,8 @@ module.exports = {
     // https://eslint.org/docs/rules/require-await
     'require-await': 'error',
 
-    /*
-     * https://eslint.org/docs/rules/require-unicode-regexp
-     * TODO turn on?
-     */
-    'require-unicode-regexp': 'off',
+    // https://eslint.org/docs/rules/require-unicode-regexp
+    'require-unicode-regexp': 'error',
 
     // https://eslint.org/docs/rules/vars-on-top
     'vars-on-top': 'error',


### PR DESCRIPTION
- [deps] update `eslint-plugin-unicorn` to version `25.0.1`
- [breaking] enable `require-unicode-regexp` rule
- [breaking] enable `unicorn/consistent-destructuring` rule
- [breaking] enable `unicorn/no-new-array` rule
- [breaking] enable `unicorn/prefer-array-index-of` rule
- [breaking] enable `unicorn/prefer-regexp-test` rule