### PR TITLE
eslint-config-seekingalpha-react ver. 4.71.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 4.71.0 - 2021-07-25
+  - [breaking] set `jest/max-nested-describe` rule to `2`
+
 ## 4.70.0 - 2021-07-25
   - [deps] upgrade `eslint-plugin-jest` to version `24.4.0`
   - [deps] upgrade `eslint-plugin-flowtype` to version `5.8.1`

--- a/eslint-configs/eslint-config-seekingalpha-react/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-react",
-  "version": "4.70.0",
+  "version": "4.71.0",
   "description": "SeekingAlpha's sharable React.js ESLint config",
   "main": "index.js",
   "scripts": {

--- a/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-jest/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-jest/index.js
@@ -18,7 +18,7 @@ module.exports = {
     'jest/max-nested-describe': [
       'error',
       {
-        max: 1,
+        max: 2,
       },
     ],
 


### PR DESCRIPTION
- [breaking] set `jest/max-nested-describe` rule to `2`