### PR TITLE
eslint-config-seekingalpha-react ver. 4.72.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 4.72.0 - 2021-07-25
+  - [deps] disable `react/jsx-handler-names` rule
+
 ## 4.71.0 - 2021-07-25
   - [breaking] set `jest/max-nested-describe` rule to `2`
 

--- a/eslint-configs/eslint-config-seekingalpha-react/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-react",
-  "version": "4.71.0",
+  "version": "4.72.0",
   "description": "SeekingAlpha's sharable React.js ESLint config",
   "main": "index.js",
   "scripts": {

--- a/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-react/jsx.js
+++ b/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-react/jsx.js
@@ -68,13 +68,7 @@ module.exports = {
     ],
 
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md
-    'react/jsx-handler-names': [
-      'error',
-      {
-        eventHandlerPrefix: 'handle',
-        eventHandlerPropPrefix: 'on',
-      },
-    ],
+    'react/jsx-handler-names': ['off'],
 
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md
     'react/jsx-indent': [


### PR DESCRIPTION
[deps] disable `react/jsx-handler-names` rule

## Reasoning
The rule works only for the object methods which makes it outdated in our current codebase since most of the components are functional. If we enable it for functional components, we'd have over 1000 errors for this rule which indicates how much we need this rule.