### PR TITLE
eslint-config-seekingalpha-react ver. 4.80.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 4.80.0 - 2021-10-03
+  - [patch] fixed `jest/no-restricted-matchers` rule according to `jest/prefer-expect-resolves`
+
 ## 4.79.0 - 2021-10-03
   - [deps] upgrade `eslint-plugin-react` to version `7.26.1`
   - [deps] upgrade `eslint-plugin-flowtype` to version `6.1.0`

--- a/eslint-configs/eslint-config-seekingalpha-react/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-react",
-  "version": "4.79.0",
+  "version": "4.80.0",
   "description": "SeekingAlpha's sharable React.js ESLint config",
   "main": "index.js",
   "scripts": {

--- a/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-jest/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-jest/index.js
@@ -81,7 +81,6 @@ module.exports = {
       {
         toBeFalsy: 'Use `toBe(false)` instead.',
         toBeTruthy: 'Use `toBe(true)` instead.',
-        resolves: 'Use `expect(await promise)` instead.',
       },
     ],
 


### PR DESCRIPTION
- [patch] fixed `jest/no-restricted-matchers` rule according to `jest/prefer-expect-resolves`