### PR TITLE
eslint-config-seekingalpha-react ver. 4.86.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.86.0 - 2021-10-10
+  - [deps] upgrade `eslint-plugin-jest` to version `25.0.6`
+  - [patch: loosen rules] drop `id` from `react/forbid-dom-props` rule
+
 ## 4.85.0 - 2021-10-10
   - [deps] upgrade `eslint-plugin-jest` to version `25.0.5`
 

--- a/eslint-configs/eslint-config-seekingalpha-react/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-react/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESLint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/):
 
-    npm install eslint@7.32.0 eslint-plugin-flowtype@6.1.0 eslint-plugin-jest@25.0.5 eslint-plugin-jsx-a11y@6.4.1 eslint-plugin-react@7.26.1 eslint-plugin-react-hooks@4.2.0 --save-dev
+    npm install eslint@7.32.0 eslint-plugin-flowtype@6.1.0 eslint-plugin-jest@25.0.6 eslint-plugin-jsx-a11y@6.4.1 eslint-plugin-react@7.26.1 eslint-plugin-react-hooks@4.2.0 --save-dev
 
 Install SeekingAlpha shareable ESLint:
 

--- a/eslint-configs/eslint-config-seekingalpha-react/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-react",
-  "version": "4.85.0",
+  "version": "4.86.0",
   "description": "SeekingAlpha's sharable React.js ESLint config",
   "main": "index.js",
   "scripts": {
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "eslint": "7.32.0",
     "eslint-plugin-flowtype": "6.1.0",
-    "eslint-plugin-jest": "25.0.5",
+    "eslint-plugin-jest": "25.0.6",
     "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-react": "7.26.1",
     "eslint-plugin-react-hooks": "4.2.0"
@@ -60,7 +60,7 @@
     "eslint": "7.32.0",
     "eslint-find-rules": "3.6.1",
     "eslint-plugin-flowtype": "6.1.0",
-    "eslint-plugin-jest": "25.0.5",
+    "eslint-plugin-jest": "25.0.6",
     "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-react": "7.26.1",
     "eslint-plugin-react-hooks": "4.2.0"

--- a/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-react/react.js
+++ b/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-react/react.js
@@ -91,7 +91,6 @@ module.exports = {
           'frame',
           'frameborder',
           'hspace',
-          'id',
           'longdesc',
           'marginheight',
           'marginwidth',


### PR DESCRIPTION
- [deps] upgrade `eslint-plugin-jest` to version `25.0.6`
- [patch: loosen rules] drop `id` from `react/forbid-dom-props` rule