### PR TITLE
eslint-config-seekingalpha-react ver. 4.91.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.91.0 - 2021-11-11
+  - [deps] upgrade `eslint-plugin-jsx-a11y` to version `6.5.1`
+  - [breaking] removed deprecated `jsx-a11y/accessible-emoji` rule
+
 ## 4.90.0 - 2021-11-10
   - [deps] upgrade `eslint-plugin-jest` to version `25.2.4`
   - [deps] upgrade `eslint-plugin-react` to version `7.27.0`

--- a/eslint-configs/eslint-config-seekingalpha-react/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-react/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESLint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/):
 
-    npm install eslint@7.32.0 eslint-plugin-flowtype@6.1.1 eslint-plugin-jest@25.2.4 eslint-plugin-jsx-a11y@6.4.1 eslint-plugin-react@7.27.0 eslint-plugin-react-hooks@4.3.0 --save-dev
+    npm install eslint@7.32.0 eslint-plugin-flowtype@6.1.1 eslint-plugin-jest@25.2.4 eslint-plugin-jsx-a11y@6.5.1 eslint-plugin-react@7.27.0 eslint-plugin-react-hooks@4.3.0 --save-dev
 
 Install SeekingAlpha shareable ESLint:
 

--- a/eslint-configs/eslint-config-seekingalpha-react/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-react",
-  "version": "4.90.0",
+  "version": "4.91.0",
   "description": "SeekingAlpha's sharable React.js ESLint config",
   "main": "index.js",
   "scripts": {
@@ -52,7 +52,7 @@
     "eslint": "7.32.0",
     "eslint-plugin-flowtype": "6.1.1",
     "eslint-plugin-jest": "25.2.4",
-    "eslint-plugin-jsx-a11y": "6.4.1",
+    "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-react": "7.27.0",
     "eslint-plugin-react-hooks": "4.3.0"
   },
@@ -61,7 +61,7 @@
     "eslint-find-rules": "4.0.0",
     "eslint-plugin-flowtype": "6.1.1",
     "eslint-plugin-jest": "25.2.4",
-    "eslint-plugin-jsx-a11y": "6.4.1",
+    "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-react": "7.27.0",
     "eslint-plugin-react-hooks": "4.3.0"
   }

--- a/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-jsx-a11y/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-react/rules/eslint-plugin-jsx-a11y/index.js
@@ -6,9 +6,6 @@ module.exports = {
 
   rules: {
 
-    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md
-    'jsx-a11y/accessible-emoji': 'error',
-
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md
     'jsx-a11y/alt-text': [
       'error',


### PR DESCRIPTION
- [deps] upgrade `eslint-plugin-jsx-a11y` to version `6.5.1`
- [breaking] removed deprecated `jsx-a11y/accessible-emoji` rule