### PR TITLE
eslint-config-seekingalpha-base ver. 5.2.1

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-base/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-base/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 5.2.1 - 2021-01-09
+  - [deps] revert `eslint-plugin-import` to version `2.25.3`
+
 ## 5.2.0 - 2021-01-06
   - [deps] update `eslint-plugin-import` to version `2.25.4`
   - [deps] update `eslint-find-rules` to version `4.1.0`

--- a/eslint-configs/eslint-config-seekingalpha-base/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-base/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESLint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/):
 
-    npm install eslint@8.6.0 eslint-plugin-array-func@3.1.7 eslint-plugin-import@2.25.5 eslint-plugin-no-use-extend-native@0.5.0 eslint-plugin-promise@6.0.0 eslint-plugin-unicorn@40.0.0 --save-dev
+    npm install eslint@8.6.0 eslint-plugin-array-func@3.1.7 eslint-plugin-import@2.25.3 eslint-plugin-no-use-extend-native@0.5.0 eslint-plugin-promise@6.0.0 eslint-plugin-unicorn@40.0.0 --save-dev
 
 Install SeekingAlpha shareable ESLint:
 

--- a/eslint-configs/eslint-config-seekingalpha-base/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-base",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "SeekingAlpha's sharable base ESLint config",
   "main": "index.js",
   "scripts": {
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "eslint": "8.6.0",
     "eslint-plugin-array-func": "3.1.7",
-    "eslint-plugin-import": "2.25.4",
+    "eslint-plugin-import": "2.25.3",
     "eslint-plugin-no-use-extend-native": "0.5.0",
     "eslint-plugin-promise": "6.0.0",
     "eslint-plugin-unicorn": "40.0.0"
@@ -59,7 +59,7 @@
     "eslint": "8.6.0",
     "eslint-find-rules": "4.1.0",
     "eslint-plugin-array-func": "3.1.7",
-    "eslint-plugin-import": "2.25.4",
+    "eslint-plugin-import": "2.25.3",
     "eslint-plugin-no-use-extend-native": "0.5.0",
     "eslint-plugin-promise": "6.0.0",
     "eslint-plugin-unicorn": "40.0.0"


### PR DESCRIPTION
- [deps] revert `eslint-plugin-import` to version `2.25.3`