### PR TITLE
eslint-config-seekingalpha-react ver. 5.21.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-react/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 5.21.0 - 2021-06-15
+  - [deps] upgrade `eslint-plugin-react-hooks` to version `4.6.0`
+
 ## 5.20.0 - 2021-06-06
   - [deps] upgrade `eslint` to version `8.17.0`
 

--- a/eslint-configs/eslint-config-seekingalpha-react/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-react/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESLint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/):
 
-    npm install eslint@8.17.0 eslint-plugin-flowtype@8.0.3 eslint-plugin-jsx-a11y@6.5.1 eslint-plugin-react@7.30.0 eslint-plugin-react-hooks@4.5.0 --save-dev
+    npm install eslint@8.17.0 eslint-plugin-flowtype@8.0.3 eslint-plugin-jsx-a11y@6.5.1 eslint-plugin-react@7.30.0 eslint-plugin-react-hooks@4.6.0 --save-dev
 
 Install SeekingAlpha shareable ESLint:
 

--- a/eslint-configs/eslint-config-seekingalpha-react/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-react",
-  "version": "5.20.0",
+  "version": "5.21.0",
   "description": "SeekingAlpha's sharable React.js ESLint config",
   "main": "index.js",
   "scripts": {
@@ -53,7 +53,7 @@
     "eslint-plugin-flowtype": "8.0.3",
     "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-react": "7.30.0",
-    "eslint-plugin-react-hooks": "4.5.0"
+    "eslint-plugin-react-hooks": "4.6.0"
   },
   "devDependencies": {
     "eslint": "8.17.0",
@@ -61,6 +61,6 @@
     "eslint-plugin-flowtype": "8.0.3",
     "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-react": "7.30.0",
-    "eslint-plugin-react-hooks": "4.5.0"
+    "eslint-plugin-react-hooks": "4.6.0"
   }
 }


### PR DESCRIPTION
- [deps] upgrade `eslint-plugin-react-hooks` to version `4.6.0`