### PR TITLE
eslint-config-seekingalpha-tests ver. 1.22.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-tests/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-tests/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.22.0 - 2022-06-16
+  - [breaking] update `testing-library/no-await-sync-events` rule
+
 ## 1.21.0 - 2022-06-06
   - [deps] upgrade `eslint` to version `8.17.0`
   - [deps] upgrade `eslint-plugin-jest` to version `26.5.3`

--- a/eslint-configs/eslint-config-seekingalpha-tests/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-tests",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "SeekingAlpha's sharable testing ESLint config",
   "main": "index.js",
   "scripts": {

--- a/eslint-configs/eslint-config-seekingalpha-tests/rules/eslint-plugin-testing-library/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-tests/rules/eslint-plugin-testing-library/index.js
@@ -21,7 +21,12 @@ module.exports = {
     'testing-library/consistent-data-testid': 'off',
 
     // https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-await-sync-events.md
-    'testing-library/no-await-sync-events': 'error',
+    'testing-library/no-await-sync-events': [
+      'error',
+      {
+        eventModules: ['fire-event'],
+      },
+    ],
 
     // https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-await-sync-query.md
     'testing-library/no-await-sync-query': 'error',


### PR DESCRIPTION
- [breaking] update `testing-library/no-await-sync-events` rule