### PR TITLE
eslint-config-seekingalpha-tests ver. 1.26.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-tests/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-tests/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.26.0 - 2022-07-31
+  - [deps] upgrade `eslint-plugin-jest` to version `26.7.0`
+  - [deps] upgrade `eslint-plugin-testing-library` to version `5.6.0`
+  - [breaking] enable `jest/prefer-mock-promise-shorthand` rule
+
 ## 1.25.0 - 2022-07-17
   - [deps] upgrade `eslint` to version `8.20.0`
 

--- a/eslint-configs/eslint-config-seekingalpha-tests/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-tests/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESLint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/):
 
-    npm install eslint@8.20.0 eslint-plugin-jest@26.6.0 eslint-plugin-testing-library@5.5.1 --save-dev
+    npm install eslint@8.20.0 eslint-plugin-jest@26.7.0 eslint-plugin-testing-library@5.6.0 --save-dev
 
 Install SeekingAlpha shareable ESLint:
 

--- a/eslint-configs/eslint-config-seekingalpha-tests/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-tests",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "SeekingAlpha's sharable testing ESLint config",
   "main": "index.js",
   "scripts": {
@@ -39,13 +39,13 @@
   },
   "peerDependencies": {
     "eslint": "8.20.0",
-    "eslint-plugin-jest": "26.6.0",
-    "eslint-plugin-testing-library": "5.5.1"
+    "eslint-plugin-jest": "26.7.0",
+    "eslint-plugin-testing-library": "5.6.0"
   },
   "devDependencies": {
     "eslint": "8.20.0",
     "eslint-find-rules": "4.1.0",
-    "eslint-plugin-jest": "26.6.0",
-    "eslint-plugin-testing-library": "5.5.1"
+    "eslint-plugin-jest": "26.7.0",
+    "eslint-plugin-testing-library": "5.6.0"
   }
 }

--- a/eslint-configs/eslint-config-seekingalpha-tests/rules/eslint-plugin-jest/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-tests/rules/eslint-plugin-jest/index.js
@@ -17,6 +17,8 @@ module.exports = {
     // https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-lowercase-title.md
     'jest/prefer-lowercase-title': 'off',
 
+    'jest/prefer-mock-promise-shorthand': 'error',
+
     // https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-snapshot-hint.md
     'jest/prefer-snapshot-hint': 'off',
 


### PR DESCRIPTION
- [deps] upgrade `eslint-plugin-jest` to version `26.7.0`
- [deps] upgrade `eslint-plugin-testing-library` to version `5.6.0`
- [breaking] enable `jest/prefer-mock-promise-shorthand` rule