### PR TITLE
eslint-config-seekingalpha-tests ver. 1.36.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-tests/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-tests/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.36.0 - 2022-08-29
+  - [deps] upgrade `eslint-plugin-jest` to version `27.0.1`
+  - [breaking] enable `jest/no-jest-import` rule
+
 ## 1.35.0 - 2022-08-27
   - [deps] upgrade `eslint` to version `8.23.0`
 

--- a/eslint-configs/eslint-config-seekingalpha-tests/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-tests/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESLint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/):
 
-    npm install eslint@8.23.0 eslint-plugin-jest@26.8.7 eslint-plugin-testing-library@5.6.0 --save-dev
+    npm install eslint@8.23.0 eslint-plugin-jest@27.0.1 eslint-plugin-testing-library@5.6.0 --save-dev
 
 Install SeekingAlpha shareable ESLint:
 

--- a/eslint-configs/eslint-config-seekingalpha-tests/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-tests",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "SeekingAlpha's sharable testing ESLint config",
   "main": "index.js",
   "scripts": {
@@ -39,13 +39,13 @@
   },
   "peerDependencies": {
     "eslint": "8.23.0",
-    "eslint-plugin-jest": "26.8.7",
+    "eslint-plugin-jest": "27.0.1",
     "eslint-plugin-testing-library": "5.6.0"
   },
   "devDependencies": {
     "eslint": "8.23.0",
     "eslint-find-rules": "4.1.0",
-    "eslint-plugin-jest": "26.8.7",
+    "eslint-plugin-jest": "27.0.1",
     "eslint-plugin-testing-library": "5.6.0"
   }
 }

--- a/eslint-configs/eslint-config-seekingalpha-tests/rules/eslint-plugin-jest/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-tests/rules/eslint-plugin-jest/index.js
@@ -14,6 +14,9 @@ module.exports = {
     // https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/max-expects.md
     'jest/max-expects': 'off',
 
+    // https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-each.md
+    'jest/prefer-each': 'error',
+
     // https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-lowercase-title.md
     'jest/prefer-lowercase-title': 'off',
 
@@ -68,9 +71,6 @@ module.exports = {
 
     // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-jasmine-globals.md
     'jest/no-jasmine-globals': 'error',
-
-    // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-jest-import.md
-    'jest/no-jest-import': 'error',
 
     // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-large-snapshots.md
     'jest/no-large-snapshots': [


### PR DESCRIPTION
- [deps] upgrade `eslint-plugin-jest` to version `27.0.1`
- [breaking] enable `jest/no-jest-import` rule