### PR TITLE
eslint-config-seekingalpha-base ver. 5.38.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-base/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-base/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 5.38.0 - 2022-12-06
+  - [breaking] `lines-around-comment` rule - ignore `@ts-expect-error` comments
+
+## 5.37.0 - 2022-12-06
+  - skipped
+
 ## 5.36.0 - 2022-11-06
   - [deps] update `eslint` to version `8.27.0`
   - [breaking] enable `no-new-native-nonconstructor` rule

--- a/eslint-configs/eslint-config-seekingalpha-base/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-base",
-  "version": "5.37.0",
+  "version": "5.38.0",
   "description": "SeekingAlpha's sharable base ESLint config",
   "main": "index.js",
   "scripts": {

--- a/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/layout-and-formatting.js
+++ b/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/layout-and-formatting.js
@@ -242,7 +242,7 @@ module.exports = {
         allowClassStart: true,
         allowClassEnd: false,
         applyDefaultIgnorePatterns: true,
-        ignorePattern: 'ignore-comment',
+        ignorePattern: '@ts-expect-error',
       },
     ],
 


### PR DESCRIPTION
- [breaking] `lines-around-comment` rule - ignore `@ts-expect-error` comments