### PR TITLE
eslint-config-seekingalpha-typescript ver. 1.0.2

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.0.2 - 2022-12-08
+  - [breaking] relax `@typescript-eslint/no-magic-numbers` rule for types
+
 ## 1.0.1 - 2022-11-09
  - [breaking] update `@typescript-eslint/space-before-function-paren` rule preferences
  - [breaking] update `@typescript-eslint/brace-style` rule preferences

--- a/eslint-configs/eslint-config-seekingalpha-typescript/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-typescript",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "SeekingAlpha's sharable typescript ESLint config",
   "main": "index.js",
   "scripts": {

--- a/eslint-configs/eslint-config-seekingalpha-typescript/rules/config.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/rules/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  indent: 2,
+};

--- a/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
@@ -1,3 +1,5 @@
+const config = require('../config');
+
 module.exports = {
   plugins: ['@typescript-eslint/eslint-plugin'],
 
@@ -69,7 +71,7 @@ module.exports = {
 
     '@typescript-eslint/indent': [
       'error',
-      2,
+      config.indent,
       {
         SwitchCase: 1,
         VariableDeclarator: 1,
@@ -175,7 +177,6 @@ module.exports = {
       {
         // These numbers are used in simple cases, we can exclude them
         ignore: [
-          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
           -1,
           0,
           1,
@@ -183,6 +184,10 @@ module.exports = {
         ignoreArrayIndexes: true,
         enforceConst: true,
         detectObjects: false,
+        ignoreEnums: true,
+        ignoreNumericLiteralTypes: true,
+        ignoreReadonlyClassProperties: false,
+        ignoreTypeIndexes: true,
       },
     ],
 


### PR DESCRIPTION
- [breaking] relax `@typescript-eslint/no-magic-numbers` rule for types