### PR TITLE
eslint-config-seekingalpha-typescript

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 1.0.2 - 2022-12-08
+## 1.0.3 - 2022-12-08
   - [breaking] relax `@typescript-eslint/no-magic-numbers` rule for types
 
 ## 1.0.2 - 2022-12-08

--- a/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 1.0.2 - 2022-12-08
   - [breaking] relax `@typescript-eslint/no-magic-numbers` rule for types
 
+## 1.0.2 - 2022-12-08
+  - [breaking] relax `@typescript-eslint/no-magic-numbers` rule for types
+
 ## 1.0.1 - 2022-11-09
  - [breaking] update `@typescript-eslint/space-before-function-paren` rule preferences
  - [breaking] update `@typescript-eslint/brace-style` rule preferences

--- a/eslint-configs/eslint-config-seekingalpha-typescript/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-typescript",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "SeekingAlpha's sharable typescript ESLint config",
   "main": "index.js",
   "scripts": {

--- a/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
@@ -186,7 +186,7 @@ module.exports = {
         detectObjects: false,
         ignoreEnums: true,
         ignoreNumericLiteralTypes: true,
-        ignoreReadonlyClassProperties: false,
+        ignoreReadonlyClassProperties: true,
         ignoreTypeIndexes: true,
       },
     ],


### PR DESCRIPTION
- [breaking] relax `@typescript-eslint/no-magic-numbers` rule for types