### PR TITLE
eslint-config-seekingalpha-typescript ver. 1.0.4

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 1.0.3 - 2022-12-08
+## 1.0.4 - 2022-12-08
   - [breaking] disable `no-undef` rule
 
 ## 1.0.3 - 2022-12-08

--- a/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## 1.0.3 - 2022-12-08
+  - [breaking] disable `no-undef` rule
+
+## 1.0.3 - 2022-12-08
   - [breaking] relax `@typescript-eslint/no-magic-numbers` rule for types
 
 ## 1.0.2 - 2022-12-08

--- a/eslint-configs/eslint-config-seekingalpha-typescript/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-typescript",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "SeekingAlpha's sharable typescript ESLint config",
   "main": "index.js",
   "scripts": {

--- a/eslint-configs/eslint-config-seekingalpha-typescript/rules/disable-recommended-eslint-rules/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/rules/disable-recommended-eslint-rules/index.js
@@ -2,6 +2,12 @@ module.exports = {
   rules: {
 
     /*
+     * Disabled as per TS recommendation
+     * https://typescript-eslint.io/linting/troubleshooting#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
+     */
+    'no-undef': 'off',
+
+    /*
      * the rule doesn't work for TypeScript
      * replacement: @typescript-eslint/brace-style
      */
@@ -41,7 +47,7 @@ module.exports = {
      * the rule doesn't work for TypeScript
      * replacement: @typescript-eslint/indent
      */
-    'indent': 'off',
+    indent: 'off',
 
     /*
      * the rule doesn't work for TypeScript
@@ -185,7 +191,7 @@ module.exports = {
      * the rule doesn't work for TypeScript
      * replacement: @typescript-eslint/quotes
      */
-    'quotes': 'off',
+    quotes: 'off',
 
     /*
      * the rule doesn't work for TypeScript
@@ -203,7 +209,7 @@ module.exports = {
      * the rule doesn't work for TypeScript
      * replacement: @typescript-eslint/semi
      */
-    'semi': 'off',
+    semi: 'off',
 
     /*
      * the rule doesn't work for TypeScript


### PR DESCRIPTION
- [breaking] disable `no-undef` rule