### PR TITLE
eslint-config-seekingalpha-typescript ver. 1.12.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.12.0 - 2023-01-31
+  - [deps] upgrade `@typescript-eslint/eslint-plugin` to version `5.49.0`
+  - [breaking] enable `@typescript-eslint/key-spacing` rule
+
 ## 1.11.0 - 2023-01-29
   - [deps] upgrade `eslint` to version `8.33.0`
 

--- a/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## 1.12.0 - 2023-01-31
-  - [deps] upgrade `@typescript-eslint/eslint-plugin` to version `5.49.0`
+  - [deps] upgrade `@typescript-eslint/eslint-plugin` to version `5.50.0`
   - [breaking] enable `@typescript-eslint/key-spacing` rule
 
 ## 1.11.0 - 2023-01-29

--- a/eslint-configs/eslint-config-seekingalpha-typescript/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESLint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/):
 
-    npm install eslint@8.33.0 @typescript-eslint/eslint-plugin@5.49.0 --save-dev
+    npm install eslint@8.33.0 @typescript-eslint/eslint-plugin@5.50.0 --save-dev
 
 Install SeekingAlpha shareable ESLint:
 

--- a/eslint-configs/eslint-config-seekingalpha-typescript/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-typescript",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "SeekingAlpha's sharable typescript ESLint config",
   "main": "index.js",
   "scripts": {
@@ -37,11 +37,11 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "5.49.0",
+    "@typescript-eslint/eslint-plugin": "5.50.0",
     "eslint": "8.33.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "5.49.0",
+    "@typescript-eslint/eslint-plugin": "5.50.0",
     "eslint": "8.33.0",
     "eslint-find-rules": "4.1.0"
   }

--- a/eslint-configs/eslint-config-seekingalpha-typescript/rules/disable-recommended-eslint-rules/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/rules/disable-recommended-eslint-rules/index.js
@@ -98,5 +98,7 @@ module.exports = {
 
     'no-invalid-this': 'off',
 
+    'key-spacing': 'off',
+
   },
 };

--- a/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
@@ -198,6 +198,15 @@ module.exports = {
       'always',
     ],
 
+    '@typescript-eslint/key-spacing': [
+      'error',
+      {
+        beforeColon: false,
+        afterColon: true,
+        mode: 'strict',
+      },
+    ],
+
     '@typescript-eslint/keyword-spacing': [
       'error',
       {


### PR DESCRIPTION
- [deps] upgrade `@typescript-eslint/eslint-plugin` to version `5.49.0`
- [breaking] enable `@typescript-eslint/key-spacing` rule