### PR TITLE
eslint-config-seekingalpha-typescript ver. 1.21.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.21.0 - 2023-03-14
+
+- [deps] upgrade `@typescript-eslint/eslint-plugin` to version `5.55.0`
+- [breaking] enable `@typescript-eslint/block-spacing` rule
+- [breaking] enable `@typescript-eslint/no-import-type-side-effects` rule
+
 ## 1.20.0 - 2023-03-12
 
 - [deps] upgrade `eslint` to version `8.36.0`

--- a/eslint-configs/eslint-config-seekingalpha-typescript/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESLint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/):
 
-    npm install eslint@8.36.0 @typescript-eslint/eslint-plugin@5.54.1 --save-dev
+    npm install eslint@8.36.0 @typescript-eslint/eslint-plugin@5.55.1 --save-dev
 
 Install SeekingAlpha shareable ESLint:
 

--- a/eslint-configs/eslint-config-seekingalpha-typescript/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-typescript",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "SeekingAlpha's sharable typescript ESLint config",
   "main": "index.js",
   "scripts": {
@@ -37,11 +37,11 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "5.54.1",
+    "@typescript-eslint/eslint-plugin": "5.55.0",
     "eslint": "8.36.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "5.54.1",
+    "@typescript-eslint/eslint-plugin": "5.55.0",
     "eslint": "8.36.0",
     "eslint-find-rules": "4.1.0"
   }

--- a/eslint-configs/eslint-config-seekingalpha-typescript/rules/disable-recommended-eslint-rules/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/rules/disable-recommended-eslint-rules/index.js
@@ -7,6 +7,8 @@ module.exports = {
      */
     'no-undef': 'off',
 
+    'block-spacing': 'off',
+
     'brace-style': 'off',
 
     'comma-dangle': 'off',

--- a/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
@@ -99,6 +99,11 @@ module.exports = {
 
     '@typescript-eslint/ban-tslint-comment': 'error',
 
+    '@typescript-eslint/block-spacing': [
+      'error',
+      'always',
+    ],
+
     '@typescript-eslint/ban-types': 'error',
 
     '@typescript-eslint/brace-style': [
@@ -276,6 +281,8 @@ module.exports = {
     '@typescript-eslint/no-extra-semi': 'error',
 
     '@typescript-eslint/no-extraneous-class': 'error',
+
+    '@typescript-eslint/no-import-type-side-effects': 'error',
 
     '@typescript-eslint/no-inferrable-types': 'error',
 


### PR DESCRIPTION
- [deps] upgrade `@typescript-eslint/eslint-plugin` to version `5.55.0`
- [breaking] enable `@typescript-eslint/block-spacing` rule
- [breaking] enable `@typescript-eslint/no-import-type-side-effects` rule