### PR TITLE
eslint-config-seekingalpha-typescript ver. 1.23.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.23.0 - 2023-03-28
+
+- [deps] upgrade `@typescript-eslint/eslint-plugin` to version `5.57.0`
+- [breaking] enable `@typescript-eslint/no-duplicate-type-constituents` rule
+- [breaking] enable `@typescript-eslint/lines-around-comment` rule
+
 ## 1.22.0 - 2023-03-23
 
 - [deps] upgrade `@typescript-eslint/eslint-plugin` to version `5.56.0`

--- a/eslint-configs/eslint-config-seekingalpha-typescript/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESLint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/):
 
-    npm install eslint@8.36.0 @typescript-eslint/eslint-plugin@5.56.0 --save-dev
+    npm install eslint@8.36.0 @typescript-eslint/eslint-plugin@5.57.0 --save-dev
 
 Install SeekingAlpha shareable ESLint:
 

--- a/eslint-configs/eslint-config-seekingalpha-typescript/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-typescript",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "SeekingAlpha's sharable typescript ESLint config",
   "main": "index.js",
   "scripts": {
@@ -37,11 +37,11 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "5.56.0",
+    "@typescript-eslint/eslint-plugin": "5.57.0",
     "eslint": "8.36.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "5.56.0",
+    "@typescript-eslint/eslint-plugin": "5.57.0",
     "eslint": "8.36.0",
     "eslint-find-rules": "4.1.0"
   }

--- a/eslint-configs/eslint-config-seekingalpha-typescript/rules/disable-recommended-eslint-rules/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/rules/disable-recommended-eslint-rules/index.js
@@ -30,6 +30,8 @@ module.exports = {
 
     'keyword-spacing': 'off',
 
+    'lines-around-comment': 'off',
+
     'lines-between-class-members': 'off',
 
     'no-array-constructor': 'off',

--- a/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
@@ -233,6 +233,36 @@ module.exports = {
       },
     ],
 
+    '@typescript-eslint/lines-around-comment': [
+      'error',
+      {
+        beforeBlockComment: true,
+        afterBlockComment: false,
+        beforeLineComment: true,
+        afterLineComment: false,
+        allowBlockStart: true,
+        allowBlockEnd: false,
+        allowObjectStart: true,
+        allowObjectEnd: false,
+        allowArrayStart: false,
+        allowArrayEnd: false,
+        allowClassStart: true,
+        allowClassEnd: false,
+        applyDefaultIgnorePatterns: true,
+        ignorePattern: '@ts-expect-error',
+
+        // typescript extension
+        allowEnumEnd: true,
+        allowEnumStart: true,
+        allowInterfaceEnd: true,
+        allowInterfaceStart: true,
+        allowModuleEnd: true,
+        allowModuleStart: true,
+        allowTypeEnd: true,
+        allowTypeStart: true,
+      },
+    ],
+
     '@typescript-eslint/lines-between-class-members': [
       'error',
       'always',
@@ -483,6 +513,8 @@ module.exports = {
     '@typescript-eslint/typedef': 'error',
 
     '@typescript-eslint/unified-signatures': 'error',
+
+    '@typescript-eslint/no-duplicate-type-constituents': 'error',
 
     '@typescript-eslint/no-extra-parens': [
       'error',


### PR DESCRIPTION
- [deps] upgrade `@typescript-eslint/eslint-plugin` to version `5.57.0`
- [breaking] enable `@typescript-eslint/no-duplicate-type-constituents` rule
- [breaking] enable `@typescript-eslint/lines-around-comment` rule