### PR TITLE
eslint-config-seekingalpha-typescript ver. 1.23.1

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.23.1 - 2023-03-28
+
+- [breaking] disable `@typescript-eslint/no-duplicate-type-constituents` rule
+
 ## 1.23.0 - 2023-03-28
 
 - [deps] upgrade `@typescript-eslint/eslint-plugin` to version `5.57.0`

--- a/eslint-configs/eslint-config-seekingalpha-typescript/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-typescript",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "SeekingAlpha's sharable typescript ESLint config",
   "main": "index.js",
   "scripts": {

--- a/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
@@ -19,6 +19,8 @@ const rulesRunTs = {
 
   '@typescript-eslint/no-base-to-string': 'off',
 
+  '@typescript-eslint/no-duplicate-type-constituents': 'off',
+
   '@typescript-eslint/no-for-in-array': 'off',
 
   '@typescript-eslint/no-misused-promises': 'off',
@@ -513,8 +515,6 @@ module.exports = {
     '@typescript-eslint/typedef': 'error',
 
     '@typescript-eslint/unified-signatures': 'error',
-
-    '@typescript-eslint/no-duplicate-type-constituents': 'error',
 
     '@typescript-eslint/no-extra-parens': [
       'error',


### PR DESCRIPTION
- [breaking] disable `@typescript-eslint/no-duplicate-type-constituents` rule