### PR TITLE
eslint-config-seekingalpha-tests ver. 1.74.1

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-tests/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-tests/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.74.1 - 2023-08-12
+
+- [breaking] removed deprecated `testing-library/no-wait-for-empty-callback` rule
+
 ## 1.74.0 - 2023-08-12
 
 - [deps] upgrade `eslint` to version `8.47.0`

--- a/eslint-configs/eslint-config-seekingalpha-tests/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-tests",
-  "version": "1.74.0",
+  "version": "1.74.1",
   "description": "SeekingAlpha's sharable testing ESLint config",
   "main": "index.js",
   "scripts": {

--- a/eslint-configs/eslint-config-seekingalpha-tests/rules/eslint-plugin-testing-library/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-tests/rules/eslint-plugin-testing-library/index.js
@@ -54,9 +54,6 @@ module.exports = {
     // https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-unnecessary-act.md
     'testing-library/no-unnecessary-act': 'error',
 
-    // https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-wait-for-empty-callback.md
-    'testing-library/no-wait-for-empty-callback': 'error',
-
     // https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-wait-for-multiple-assertions.md
     'testing-library/no-wait-for-multiple-assertions': 'error',
 


### PR DESCRIPTION
- [breaking] removed deprecated `testing-library/no-wait-for-empty-callback` rule