### PR TITLE
eslint-config-seekingalpha-tests ver. 1.77.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-tests/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-tests/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.77.0 - 2023-09-18
+
+- [deps] upgrade `eslint-plugin-jest` to version `27.4.0`
+- [breaking] enable `jest/no-confusing-set-timeout` rule
+
 ## 1.76.0 - 2023-09-11
 
 - [deps] upgrade `eslint` to version `8.49.0`

--- a/eslint-configs/eslint-config-seekingalpha-tests/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-tests/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESLint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/):
 
-    npm install eslint@8.49.0 eslint-plugin-jest@27.2.3 eslint-plugin-testing-library@6.0.1 --save-dev
+    npm install eslint@8.49.0 eslint-plugin-jest@27.4.0 eslint-plugin-testing-library@6.0.1 --save-dev
 
 Install SeekingAlpha shareable ESLint:
 

--- a/eslint-configs/eslint-config-seekingalpha-tests/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-tests",
-  "version": "1.76.0",
+  "version": "1.77.0",
   "description": "SeekingAlpha's sharable testing ESLint config",
   "main": "index.js",
   "scripts": {
@@ -39,13 +39,13 @@
   },
   "peerDependencies": {
     "eslint": "8.49.0",
-    "eslint-plugin-jest": "27.2.3",
+    "eslint-plugin-jest": "27.4.0",
     "eslint-plugin-testing-library": "6.0.1"
   },
   "devDependencies": {
     "eslint": "8.49.0",
     "eslint-find-rules": "4.1.0",
-    "eslint-plugin-jest": "27.2.3",
+    "eslint-plugin-jest": "27.4.0",
     "eslint-plugin-testing-library": "6.0.1"
   }
 }

--- a/eslint-configs/eslint-config-seekingalpha-tests/rules/eslint-plugin-jest/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-tests/rules/eslint-plugin-jest/index.js
@@ -44,6 +44,9 @@ module.exports = {
     // https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-conditional-in-test.md
     'jest/no-conditional-in-test': 'error',
 
+    // https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-confusing-set-timeout.md
+    'jest/no-confusing-set-timeout': 'error',
+
     // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-deprecated-functions.md
     'jest/no-deprecated-functions': 'error',
 


### PR DESCRIPTION
- [deps] upgrade `eslint-plugin-jest` to version `27.4.0`
- [breaking] enable `jest/no-confusing-set-timeout` rule