### PR TITLE
eslint-config-seekingalpha-typescript ver. 4.25.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 4.25.0 - 2024-02-20
+
+- [deps] upgrade `@typescript-eslint/eslint-plugin` to version `7.0.2`
+- [deps] upgrade `@typescript-eslint/parser` to version `7.0.2`
+
 ## 4.24.0 - 2024-02-18
 
 - [deps] upgrade `@stylistic/eslint-plugin-ts` to version `1.6.2`

--- a/eslint-configs/eslint-config-seekingalpha-typescript/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESLint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/):
 
-    npm install eslint@8.56.0 @typescript-eslint/eslint-plugin@7.0.1 @typescript-eslint/parser@7.0.1 @stylistic/eslint-plugin-ts@1.6.2 --save-dev
+    npm install eslint@8.56.0 @typescript-eslint/eslint-plugin@7.0.2 @typescript-eslint/parser@7.0.2 @stylistic/eslint-plugin-ts@1.6.2 --save-dev
 
 Install SeekingAlpha shareable ESLint:
 

--- a/eslint-configs/eslint-config-seekingalpha-typescript/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-typescript",
-  "version": "4.24.0",
+  "version": "4.25.0",
   "description": "SeekingAlpha's sharable typescript ESLint config",
   "main": "index.js",
   "scripts": {
@@ -38,14 +38,14 @@
   },
   "peerDependencies": {
     "@stylistic/eslint-plugin-ts": "1.6.2",
-    "@typescript-eslint/eslint-plugin": "7.0.1",
-    "@typescript-eslint/parser": "7.0.1",
+    "@typescript-eslint/eslint-plugin": "7.0.2",
+    "@typescript-eslint/parser": "7.0.2",
     "eslint": "8.56.0"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin-ts": "1.6.2",
-    "@typescript-eslint/eslint-plugin": "7.0.1",
-    "@typescript-eslint/parser": "7.0.1",
+    "@typescript-eslint/eslint-plugin": "7.0.2",
+    "@typescript-eslint/parser": "7.0.2",
     "eslint": "8.56.0",
     "eslint-find-rules": "4.1.0"
   }


### PR DESCRIPTION
- [deps] upgrade `@typescript-eslint/eslint-plugin` to version `7.0.2`
- [deps] upgrade `@typescript-eslint/parser` to version `7.0.2`