### PR TITLE
eslint-config-seekingalpha-typescript ver. 4.35.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.35.0 - 2024-04-08
+
+- [breaking] disable `@stylistic/ts/lines-around-comment` for prettier config
+
 ## 4.34.0 - 2024-04-02
 
 - [deps] upgrade `@typescript-eslint/eslint-plugin` to version `7.5.0`

--- a/eslint-configs/eslint-config-seekingalpha-typescript/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-typescript",
-  "version": "4.34.0",
+  "version": "4.35.0",
   "description": "SeekingAlpha's sharable typescript ESLint config",
   "main": "index.js",
   "scripts": {

--- a/eslint-configs/eslint-config-seekingalpha-typescript/prettier.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/prettier.js
@@ -8,6 +8,7 @@ module.exports = {
     '@stylistic/ts/comma-spacing': 'off',
     '@stylistic/ts/function-call-spacing': 'off',
     '@stylistic/ts/indent': 'off',
+    '@stylistic/ts/lines-around-comment': 'off',
     '@stylistic/ts/key-spacing': 'off',
     '@stylistic/ts/keyword-spacing': 'off',
     '@stylistic/ts/member-delimiter-style': 'off',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seekingalpha-javascript-style",
-  "version": "5.38.10",
+  "version": "5.38.11",
   "description": "Set of linting rules, guides and best practices for best Javascript code",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
- [breaking] disable `@stylistic/ts/lines-around-comment` for prettier config