### PR TITLE
eslint-config-seekingalpha-base ver. 8.2.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-base/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-base/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 8.2.0 - 2024-05-12
+
+- [breaking] enable `logical-assignment-operators` rule
+
 ## 8.1.0 - 2024-05-12
 
 - [deps] update `eslint-plugin-unicorn` to version `53.0.0`

--- a/eslint-configs/eslint-config-seekingalpha-base/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-base",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "SeekingAlpha's sharable base ESLint config",
   "main": "index.js",
   "scripts": {

--- a/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/suggestions.js
+++ b/eslint-configs/eslint-config-seekingalpha-base/rules/eslint/suggestions.js
@@ -145,6 +145,9 @@ module.exports = {
     // https://eslint.org/docs/rules/init-declarations
     'init-declarations': ['off', 'always'],
 
+    // https://eslint.org/docs/latest/rules/logical-assignment-operators
+    'logical-assignment-operators': ['error', 'always'],
+
     // https://eslint.org/docs/rules/max-classes-per-file
     'max-classes-per-file': ['error', config.maxClassesPerFile],
 


### PR DESCRIPTION
- [breaking] enable `logical-assignment-operators` rule