### PR TITLE
eslint-config-seekingalpha-typescript ver. 5.12.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 5.12.0 - 2024-07-09
+
+- [deps] upgrade `@typescript-eslint/eslint-plugin` to version `7.16.0`
+- [deps] upgrade `@typescript-eslint/parser` to version `7.16.0`
+- [breaking] enable `@typescript-eslint/no-empty-object-type` rule
+- [breaking] enable `@typescript-eslint/no-unnecessary-parameter-property-assignment` rule
+
 ## 5.11.0 - 2024-07-02
 
 - [deps] upgrade `@typescript-eslint/eslint-plugin` to version `7.15.0`

--- a/eslint-configs/eslint-config-seekingalpha-typescript/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESLint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/):
 
-    npm install eslint@8.57.0 @typescript-eslint/eslint-plugin@7.15.0 @typescript-eslint/parser@7.15.0 --save-dev
+    npm install eslint@8.57.0 @typescript-eslint/eslint-plugin@7.16.0 @typescript-eslint/parser@7.16.0 --save-dev
 
 Install SeekingAlpha shareable ESLint:
 

--- a/eslint-configs/eslint-config-seekingalpha-typescript/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-typescript",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "description": "SeekingAlpha's sharable typescript ESLint config",
   "main": "index.js",
   "scripts": {
@@ -37,13 +37,13 @@
     "node": ">= 20"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "7.15.0",
-    "@typescript-eslint/parser": "7.15.0",
+    "@typescript-eslint/eslint-plugin": "7.16.0",
+    "@typescript-eslint/parser": "7.16.0",
     "eslint": "8.57.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "7.15.0",
-    "@typescript-eslint/parser": "7.15.0",
+    "@typescript-eslint/eslint-plugin": "7.16.0",
+    "@typescript-eslint/parser": "7.16.0",
     "eslint": "8.57.0",
     "eslint-find-rules": "4.1.0"
   }

--- a/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
@@ -106,6 +106,8 @@ const rulesRunTs = {
   '@typescript-eslint/restrict-template-expressions': 'off',
 
   '@typescript-eslint/use-unknown-in-catch-callback-variable': 'off',
+
+  '@typescript-eslint/no-unnecessary-type-parameters': 'off',
 };
 
 module.exports = {
@@ -175,6 +177,8 @@ module.exports = {
 
     '@typescript-eslint/no-empty-interface': 'error',
 
+    '@typescript-eslint/no-empty-object-type': 'error',
+
     '@typescript-eslint/no-explicit-any': 'off',
 
     '@typescript-eslint/no-extra-non-null-assertion': 'error',
@@ -234,6 +238,8 @@ module.exports = {
     ],
 
     '@typescript-eslint/no-this-alias': 'error',
+
+    '@typescript-eslint/no-unnecessary-parameter-property-assignment': 'error',
 
     '@typescript-eslint/no-unnecessary-type-constraint': 'error',
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seekingalpha-javascript-style",
-  "version": "5.38.32",
+  "version": "5.38.33",
   "description": "Set of linting rules, guides and best practices for best Javascript code",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
- [deps] upgrade `@typescript-eslint/eslint-plugin` to version `7.16.0`
- [deps] upgrade `@typescript-eslint/parser` to version `7.16.0`
- [breaking] enable `@typescript-eslint/no-empty-object-type` rule
- [breaking] enable `@typescript-eslint/no-unnecessary-parameter-property-assignment` rule