### PR TITLE
eslint-config-seekingalpha-typescript ver. 5.16.0

### DIFF
--- a/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 5.16.0 - 2024-08-01
+
+- [deps] upgrade `@typescript-eslint/eslint-plugin` to version `8.0.0`
+- [deps] upgrade `@typescript-eslint/parser` to version `8.0.0`
+- [breaking] enable `@typescript-eslint/no-unsafe-function-type` rule
+- [breaking] enable `@typescript-eslint/no-wrapper-object-types` rule
+-
+
 ## 5.15.0 - 2024-07-30
 
 - [deps] upgrade `@typescript-eslint/eslint-plugin` to version `7.18.0`

--- a/eslint-configs/eslint-config-seekingalpha-typescript/README.md
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint config used by [SeekingAlpha](https:/
 
 Install ESLint and all [Peer Dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/):
 
-    npm install eslint@8.57.0 @typescript-eslint/eslint-plugin@7.18.0 @typescript-eslint/parser@7.18.0 --save-dev
+    npm install eslint@8.57.0 @typescript-eslint/eslint-plugin@8.0.0 @typescript-eslint/parser@8.0.0 --save-dev
 
 Install SeekingAlpha shareable ESLint:
 

--- a/eslint-configs/eslint-config-seekingalpha-typescript/package.json
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-seekingalpha-typescript",
-  "version": "5.15.0",
+  "version": "5.16.0",
   "description": "SeekingAlpha's sharable typescript ESLint config",
   "main": "index.js",
   "scripts": {
@@ -37,13 +37,13 @@
     "node": ">= 20"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "7.18.0",
-    "@typescript-eslint/parser": "7.18.0",
+    "@typescript-eslint/eslint-plugin": "8.0.0",
+    "@typescript-eslint/parser": "8.0.0",
     "eslint": "8.57.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "7.18.0",
-    "@typescript-eslint/parser": "7.18.0",
+    "@typescript-eslint/eslint-plugin": "8.0.0",
+    "@typescript-eslint/parser": "8.0.0",
     "eslint": "8.57.0",
     "eslint-find-rules": "4.1.0"
   }

--- a/eslint-configs/eslint-config-seekingalpha-typescript/rules/disable-recommended-eslint-rules/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/rules/disable-recommended-eslint-rules/index.js
@@ -32,8 +32,6 @@ module.exports = {
 
     'no-loop-func': 'off',
 
-    'no-loss-of-precision': 'off',
-
     'no-magic-numbers': 'off',
 
     'no-redeclare': 'off',

--- a/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
+++ b/eslint-configs/eslint-config-seekingalpha-typescript/rules/typescript-eslint/index.js
@@ -118,6 +118,8 @@ module.exports = {
 
     '@typescript-eslint/adjacent-overload-signatures': 'error',
 
+    '@typescript-eslint/no-restricted-types': 'off',
+
     '@typescript-eslint/ban-ts-comment': 'error',
 
     '@typescript-eslint/ban-tslint-comment': 'error',
@@ -193,8 +195,6 @@ module.exports = {
 
     '@typescript-eslint/no-loop-func': 'error',
 
-    '@typescript-eslint/no-loss-of-precision': 'error',
-
     '@typescript-eslint/no-magic-numbers': [
       'error',
       {
@@ -245,6 +245,8 @@ module.exports = {
 
     '@typescript-eslint/no-unsafe-declaration-merging': 'error',
 
+    '@typescript-eslint/no-unsafe-function-type': 'error',
+
     '@typescript-eslint/no-unused-expressions': [
       'error',
       {
@@ -283,6 +285,8 @@ module.exports = {
     '@typescript-eslint/no-useless-empty-export': 'error',
 
     '@typescript-eslint/no-var-requires': 'error',
+
+    '@typescript-eslint/no-wrapper-object-types': 'error',
 
     '@typescript-eslint/prefer-as-const': 'error',
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seekingalpha-javascript-style",
-  "version": "5.38.37",
+  "version": "5.38.38",
   "description": "Set of linting rules, guides and best practices for best Javascript code",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
- [deps] upgrade `@typescript-eslint/eslint-plugin` to version `8.0.0`
- [deps] upgrade `@typescript-eslint/parser` to version `8.0.0`
- [breaking] enable `@typescript-eslint/no-unsafe-function-type` rule
- [breaking] enable `@typescript-eslint/no-wrapper-object-types` rule